### PR TITLE
Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bootsnap', require: false # Reduces boot times through caching; required in
 gem 'i18n-js', '3.5.1' # A library to provide the I18n translations on the Javascript
 gem 'httparty' # A library to make http request easier
 gem 'nokogiri' # A HTML parser library
+gem 'kaminari' # A pagination library
 
 # Authentications & Authorizations
 gem 'devise' # Authentication solution for Rails with Warden

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,18 @@ GEM
     json_matchers (0.11.1)
       json_schema
     json_schema (0.20.9)
+    kaminari (1.2.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.1)
+      kaminari-activerecord (= 1.2.1)
+      kaminari-core (= 1.2.1)
+    kaminari-actionview (1.2.1)
+      actionview
+      kaminari-core (= 1.2.1)
+    kaminari-activerecord (1.2.1)
+      activerecord
+      kaminari-core (= 1.2.1)
+    kaminari-core (1.2.1)
     kramdown (2.3.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -454,6 +466,7 @@ DEPENDENCIES
   httparty
   i18n-js (= 3.5.1)
   json_matchers
+  kaminari
   letter_opener
   listen (= 3.1.5)
   mini_magick

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,6 +16,6 @@
 // Layouts
 
 // Components
-@import 'components/card';
+@import 'components/*';
 
 // Screens

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -1,6 +1,6 @@
 .pagination {
   margin-top: 3rem;
-  margin-bottom: 0;
+  margin-bottom: 3rem;
 
   .page-link {
     color: $secondary;

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -1,0 +1,15 @@
+.pagination {
+  margin-top: 3rem;
+  margin-bottom: 0;
+
+  .page-link {
+    color: $secondary;
+  }
+
+  .page-item.active .page-link {
+    background-color: $secondary;
+    border-color: $secondary;
+  }
+}
+
+

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -10,5 +10,3 @@
     border-color: $secondary;
   }
 }
-
-

--- a/app/assets/stylesheets/components/_pagination.scss
+++ b/app/assets/stylesheets/components/_pagination.scss
@@ -1,5 +1,4 @@
 .pagination {
-  margin-top: 3rem;
   margin-bottom: 3rem;
 
   .page-link {

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -4,6 +4,7 @@ class KeywordsController < ApplicationController
   before_action :ensure_authentication
   before_action :set_csv_import_form
 
+  # Kaminari default item per page is 25
   def index
     # TODOs pagination (new ticket)
     render locals: {
@@ -41,6 +42,6 @@ class KeywordsController < ApplicationController
   end
 
   def search_keyword
-    current_user.keywords.where("keyword ILIKE '%#{params[:search]}%'").order(keyword: :asc).limit(50)
+    current_user.keywords.where("keyword ILIKE '%#{params[:search]}%'").order(keyword: :asc).page(params[:page])
   end
 end

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -6,7 +6,6 @@ class KeywordsController < ApplicationController
 
   # Kaminari default item per page is 25
   def index
-    # TODOs pagination (new ticket)
     render locals: {
       csv_import_form: @csv_import_form,
       keywords: search_keyword

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_first_page.html.slim
+++ b/app/views/kaminari/_first_page.html.slim
@@ -1,2 +1,2 @@
 li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link'
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link d-none'

--- a/app/views/kaminari/_gap.html.slim
+++ b/app/views/kaminari/_gap.html.slim
@@ -1,0 +1,2 @@
+li.page-item.disabled
+  = link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'

--- a/app/views/kaminari/_last_page.html.slim
+++ b/app/views/kaminari/_last_page.html.slim
@@ -1,2 +1,2 @@
 li.page-item
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link'
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link d-none'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_next_page.html.slim
+++ b/app/views/kaminari/_next_page.html.slim
@@ -1,2 +1,2 @@
 li.page-item
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'
+  = link_to_unless current_page.last?, t('pagination.next'), url, rel: 'next', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_page.html.slim
+++ b/app/views/kaminari/_page.html.slim
@@ -1,0 +1,6 @@
+- if page.current?
+  li.page-item.active
+    = content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link'
+- else
+  li.page-item
+    = link_to page, url, remote: remote, rel: page.rel, class: 'page-link'

--- a/app/views/kaminari/_paginator.html.slim
+++ b/app/views/kaminari/_paginator.html.slim
@@ -1,0 +1,12 @@
+= paginator.render do
+  nav
+    ul.pagination
+      == first_page_tag unless current_page.first?
+      == prev_page_tag unless current_page.first?
+      - each_page do |page|
+        - if page.left_outer? || page.right_outer? || page.inside_window?
+          == page_tag page
+        - elsif !page.was_truncated?
+          == gap_tag
+      == next_page_tag unless current_page.last?
+      == last_page_tag unless current_page.last?

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,0 +1,2 @@
+li.page-item
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/kaminari/_prev_page.html.slim
+++ b/app/views/kaminari/_prev_page.html.slim
@@ -1,2 +1,2 @@
 li.page-item
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link'
+  = link_to_unless current_page.first?, t('pagination.prev'), url, rel: 'prev', remote: remote, class: 'page-link'

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -5,7 +5,7 @@
   = render(partial: 'search_form')
 
   - if keywords.present?
-    == paginate keywords
+    == paginate keywords, left: 2, right: 2
     
     table class="table table-hover my-5 w-50"
       thead.thead-light

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -4,10 +4,8 @@
 
   = render(partial: 'search_form')
 
-  - if keywords.present?
-    == paginate keywords, left: 2, right: 2
-    
-    table class="table table-hover w-50"
+  - if keywords.present?    
+    table class="table table-hover w-50 my-5"
       thead.thead-light
         tr
           th = t('keyword.keyword')

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -7,7 +7,7 @@
   - if keywords.present?
     == paginate keywords, left: 2, right: 2
     
-    table class="table table-hover my-5 w-50"
+    table class="table table-hover w-50"
       thead.thead-light
         tr
           th = t('keyword.keyword')
@@ -15,5 +15,8 @@
           th.text-center = t('keyword.status')
       tbody
         = render(partial: 'keyword', collection: keywords)
+
+    == paginate keywords, left: 2, right: 2
+
   - else
     h2 class="mt-5 text-secondary" = t('keyword.no_keywords')

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -5,7 +5,7 @@
   = render(partial: 'search_form')
 
   - if keywords.present?
-    table class="table table-hover w-50 my-5"
+    table class="table table-hover my-5 w-50"
       thead.thead-light
         tr
           th = t('keyword.keyword')

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -5,6 +5,8 @@
   = render(partial: 'search_form')
 
   - if keywords.present?
+    == paginate keywords
+    
     table class="table table-hover my-5 w-50"
       thead.thead-light
         tr

--- a/app/views/keywords/index.html.slim
+++ b/app/views/keywords/index.html.slim
@@ -4,7 +4,7 @@
 
   = render(partial: 'search_form')
 
-  - if keywords.present?    
+  - if keywords.present?
     table class="table table-hover w-50 my-5"
       thead.thead-light
         tr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -85,3 +85,7 @@ en:
     upload: "Upload"
     upload_csv_successfully: "CSV uploaded successfully"
     upload_keywords_csv_file: "Upload keywords CSV file"
+
+  pagination:
+    next: "Next ›"
+    prev: "‹ Prev"

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -6,6 +6,8 @@ module Helpers
   end
 
   def system_login(username = 'nimblehq', password = 'password')
+    visit login_path
+
     within 'form' do
       fill_in('username', with: username)
       fill_in('password', with: password)

--- a/spec/systems/login_spec.rb
+++ b/spec/systems/login_spec.rb
@@ -22,8 +22,6 @@ describe 'Login', type: :system do
     it 'redirects to home page with greeting message' do
       user = Fabricate(:user)
 
-      visit login_path
-
       system_login
 
       expect(current_path).to eql(root_path)

--- a/spec/systems/logout_spec.rb
+++ b/spec/systems/logout_spec.rb
@@ -6,12 +6,6 @@ describe 'Logout', type: :system do
   it 'redirects to home page, displays logged out message and does NOT show greeting message and logout link in nav dropdown' do
     Fabricate(:user)
 
-    visit root_path
-
-    within 'nav' do
-      click_link(I18n.t('auth.login'))
-    end
-
     system_login
 
     find('li.nav-item').click

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 describe 'pagination', type: :system do
   ActiveJob::Base.queue_adapter = :test
 
-  context 'given 60 keywords csv' do
+  context 'given 60 keywords' do
     # 25 keywords per page
     it 'displays first page' do
       user = Fabricate(:user)
-      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
 
       visit keywords_path
 
@@ -19,10 +19,6 @@ describe 'pagination', type: :system do
 
         click_button(I18n.t('auth.login'))
       end
-
-      attach_file('csv_import_form[file]', file_path)
-
-      click_button(I18n.t('keyword.upload'))
 
       paginations = find('.pagination')
 
@@ -36,22 +32,16 @@ describe 'pagination', type: :system do
         expect(page).not_to have_content(I18n.t('pagination.prev'))
       end
 
-      within 'table' do
-        within 'tbody' do
-          expect(page).to have_selector('tr', count: 25)
-
-          tr_list = all('tr')
-
-          expect(tr_list[0]).to have_selector('td', text: 'Addie Waters')
-        end
+      within 'table tbody' do
+        expect(page).to have_selector('tr', count: 25)
       end
     end
 
     it 'displays second page' do
       user = Fabricate(:user)
-      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
 
-      visit keywords_path
+      visit keywords_path(page: 2)
 
       within 'form' do
         fill_in('username', with: user[:username])
@@ -59,12 +49,6 @@ describe 'pagination', type: :system do
 
         click_button(I18n.t('auth.login'))
       end
-
-      attach_file('csv_import_form[file]', file_path)
-
-      click_button(I18n.t('keyword.upload'))
-
-      visit keywords_path(page: 2)
 
       expect(page).to have_current_path(keywords_path(page: 2))
 
@@ -78,22 +62,16 @@ describe 'pagination', type: :system do
         expect(page).to have_content(I18n.t('pagination.prev'))
       end
 
-      within 'table' do
-        within 'tbody' do
-          expect(page).to have_selector('tr', count: 25)
-
-          tr_list = all('tr')
-
-          expect(tr_list[0]).to have_selector('td', text: 'Henrietta Taylor')
-        end
+      within 'table tbody' do
+        expect(page).to have_selector('tr', count: 25)
       end
     end
 
     it 'displays third page' do
       user = Fabricate(:user)
-      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
 
-      visit keywords_path
+      visit keywords_path(page: 3)
 
       within 'form' do
         fill_in('username', with: user[:username])
@@ -101,12 +79,6 @@ describe 'pagination', type: :system do
 
         click_button(I18n.t('auth.login'))
       end
-
-      attach_file('csv_import_form[file]', file_path)
-
-      click_button(I18n.t('keyword.upload'))
-
-      visit keywords_path(page: 3)
 
       expect(page).to have_current_path(keywords_path(page: 3))
 
@@ -121,22 +93,16 @@ describe 'pagination', type: :system do
         expect(page).not_to have_content(I18n.t('pagination.next'))
       end
 
-      within 'table' do
-        within 'tbody' do
-          expect(page).to have_selector('tr', count: 10)
-
-          tr_list = all('tr')
-
-          expect(tr_list[0]).to have_selector('td', text: 'Rhoda McDonald')
-        end
+      within 'table tbody' do
+        expect(page).to have_selector('tr', count: 10)
       end
     end
 
     it 'does NOT display keywords table when go to page 4' do
       user = Fabricate(:user)
-      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
 
-      visit keywords_path
+      visit keywords_path(page: 4)
 
       within 'form' do
         fill_in('username', with: user[:username])
@@ -144,12 +110,6 @@ describe 'pagination', type: :system do
 
         click_button(I18n.t('auth.login'))
       end
-
-      attach_file('csv_import_form[file]', file_path)
-
-      click_button(I18n.t('keyword.upload'))
-
-      visit keywords_path(page: 4)
 
       expect(page).not_to have_selector('table')
 

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -7,11 +7,11 @@ describe 'pagination', type: :system do
     # 25 keywords per page
     it 'displays first page' do
       user = Fabricate(:user)
-      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
+      Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
       visit keywords_path
 
-      system_login(user.username, 'password')
+      system_login
 
       paginations = find('.pagination')
 
@@ -32,11 +32,11 @@ describe 'pagination', type: :system do
 
     it 'displays second page' do
       user = Fabricate(:user)
-      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
+      Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
       visit keywords_path(page: 2)
 
-      system_login(user.username, 'password')
+      system_login
 
       expect(page).to have_current_path(keywords_path(page: 2))
 
@@ -57,11 +57,11 @@ describe 'pagination', type: :system do
 
     it 'displays third page' do
       user = Fabricate(:user)
-      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
+      Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
       visit keywords_path(page: 3)
 
-      system_login(user.username, 'password')
+      system_login
 
       expect(page).to have_current_path(keywords_path(page: 3))
 
@@ -83,11 +83,11 @@ describe 'pagination', type: :system do
 
     it 'does NOT display keywords table when go to page 4' do
       user = Fabricate(:user)
-      Fabricate.times(60, :keyword, user_id: user[:id], keyword: FFaker::Name.name)
+      Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
       visit keywords_path(page: 4)
 
-      system_login(user.username, 'password')
+      system_login
 
       expect(page).not_to have_selector('table')
 

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -24,9 +24,9 @@ describe 'pagination', type: :system do
 
       click_button(I18n.t('keyword.upload'))
 
-      paginations = all('.pagination')
+      paginations = find('.pagination')
 
-      within paginations[0] do
+      within paginations do
         expect(page).to have_content('1')
         expect(page).to have_content('2')
         expect(page).to have_content('3')
@@ -68,9 +68,9 @@ describe 'pagination', type: :system do
 
       expect(page).to have_current_path(keywords_path(page: 2))
 
-      paginations = all('.pagination')
+      paginations = find('.pagination')
 
-      within paginations[0] do
+      within paginations do
         expect(page).to have_content('1')
         expect(page).to have_content('2')
         expect(page).to have_content('3')
@@ -110,9 +110,9 @@ describe 'pagination', type: :system do
 
       expect(page).to have_current_path(keywords_path(page: 3))
 
-      paginations = all('.pagination')
+      paginations = find('.pagination')
 
-      within paginations[0] do
+      within paginations do
         expect(page).to have_content('1')
         expect(page).to have_content('2')
         expect(page).to have_content('3')

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -9,9 +9,9 @@ describe 'pagination', type: :system do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       paginations = find('.pagination')
 
@@ -34,9 +34,9 @@ describe 'pagination', type: :system do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
-      visit keywords_path(page: 2)
-
       system_login
+
+      visit keywords_path(page: 2)
 
       expect(page).to have_current_path(keywords_path(page: 2))
 
@@ -59,9 +59,9 @@ describe 'pagination', type: :system do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
-      visit keywords_path(page: 3)
-
       system_login
+
+      visit keywords_path(page: 3)
 
       expect(page).to have_current_path(keywords_path(page: 3))
 
@@ -85,9 +85,9 @@ describe 'pagination', type: :system do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
-      visit keywords_path(page: 4)
-
       system_login
+
+      visit keywords_path(page: 4)
 
       expect(page).not_to have_selector('table')
 

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -3,8 +3,6 @@
 require 'rails_helper'
 
 describe 'pagination', type: :system do
-  ActiveJob::Base.queue_adapter = :test
-
   context 'given 60 keywords' do
     # 25 keywords per page
     it 'displays first page' do
@@ -13,12 +11,7 @@ describe 'pagination', type: :system do
 
       visit keywords_path
 
-      within 'form' do
-        fill_in('username', with: user[:username])
-        fill_in('password', with: 'password')
-
-        click_button(I18n.t('auth.login'))
-      end
+      system_login(user.username, 'password')
 
       paginations = find('.pagination')
 
@@ -43,12 +36,7 @@ describe 'pagination', type: :system do
 
       visit keywords_path(page: 2)
 
-      within 'form' do
-        fill_in('username', with: user[:username])
-        fill_in('password', with: 'password')
-
-        click_button(I18n.t('auth.login'))
-      end
+      system_login(user.username, 'password')
 
       expect(page).to have_current_path(keywords_path(page: 2))
 
@@ -73,12 +61,7 @@ describe 'pagination', type: :system do
 
       visit keywords_path(page: 3)
 
-      within 'form' do
-        fill_in('username', with: user[:username])
-        fill_in('password', with: 'password')
-
-        click_button(I18n.t('auth.login'))
-      end
+      system_login(user.username, 'password')
 
       expect(page).to have_current_path(keywords_path(page: 3))
 
@@ -104,12 +87,7 @@ describe 'pagination', type: :system do
 
       visit keywords_path(page: 4)
 
-      within 'form' do
-        fill_in('username', with: user[:username])
-        fill_in('password', with: 'password')
-
-        click_button(I18n.t('auth.login'))
-      end
+      system_login(user.username, 'password')
 
       expect(page).not_to have_selector('table')
 

--- a/spec/systems/pagination_spec.rb
+++ b/spec/systems/pagination_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'pagination', type: :system do
+  ActiveJob::Base.queue_adapter = :test
+
+  context 'given 60 keywords csv' do
+    # 25 keywords per page
+    it 'displays first page' do
+      user = Fabricate(:user)
+      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+
+      visit keywords_path
+
+      within 'form' do
+        fill_in('username', with: user[:username])
+        fill_in('password', with: 'password')
+
+        click_button(I18n.t('auth.login'))
+      end
+
+      attach_file('csv_import_form[file]', file_path)
+
+      click_button(I18n.t('keyword.upload'))
+
+      paginations = all('.pagination')
+
+      within paginations[0] do
+        expect(page).to have_content('1')
+        expect(page).to have_content('2')
+        expect(page).to have_content('3')
+        expect(page).to have_content(I18n.t('pagination.next'))
+
+        expect(page).not_to have_content('4')
+        expect(page).not_to have_content(I18n.t('pagination.prev'))
+      end
+
+      within 'table' do
+        within 'tbody' do
+          expect(page).to have_selector('tr', count: 25)
+
+          tr_list = all('tr')
+
+          expect(tr_list[0]).to have_selector('td', text: 'Addie Waters')
+        end
+      end
+    end
+
+    it 'displays second page' do
+      user = Fabricate(:user)
+      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+
+      visit keywords_path
+
+      within 'form' do
+        fill_in('username', with: user[:username])
+        fill_in('password', with: 'password')
+
+        click_button(I18n.t('auth.login'))
+      end
+
+      attach_file('csv_import_form[file]', file_path)
+
+      click_button(I18n.t('keyword.upload'))
+
+      visit keywords_path(page: 2)
+
+      expect(page).to have_current_path(keywords_path(page: 2))
+
+      paginations = all('.pagination')
+
+      within paginations[0] do
+        expect(page).to have_content('1')
+        expect(page).to have_content('2')
+        expect(page).to have_content('3')
+        expect(page).to have_content(I18n.t('pagination.next'))
+        expect(page).to have_content(I18n.t('pagination.prev'))
+      end
+
+      within 'table' do
+        within 'tbody' do
+          expect(page).to have_selector('tr', count: 25)
+
+          tr_list = all('tr')
+
+          expect(tr_list[0]).to have_selector('td', text: 'Henrietta Taylor')
+        end
+      end
+    end
+
+    it 'displays third page' do
+      user = Fabricate(:user)
+      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+
+      visit keywords_path
+
+      within 'form' do
+        fill_in('username', with: user[:username])
+        fill_in('password', with: 'password')
+
+        click_button(I18n.t('auth.login'))
+      end
+
+      attach_file('csv_import_form[file]', file_path)
+
+      click_button(I18n.t('keyword.upload'))
+
+      visit keywords_path(page: 3)
+
+      expect(page).to have_current_path(keywords_path(page: 3))
+
+      paginations = all('.pagination')
+
+      within paginations[0] do
+        expect(page).to have_content('1')
+        expect(page).to have_content('2')
+        expect(page).to have_content('3')
+        expect(page).to have_content(I18n.t('pagination.prev'))
+
+        expect(page).not_to have_content(I18n.t('pagination.next'))
+      end
+
+      within 'table' do
+        within 'tbody' do
+          expect(page).to have_selector('tr', count: 10)
+
+          tr_list = all('tr')
+
+          expect(tr_list[0]).to have_selector('td', text: 'Rhoda McDonald')
+        end
+      end
+    end
+
+    it 'does NOT display keywords table when go to page 4' do
+      user = Fabricate(:user)
+      file_path = Rails.root.join('spec', 'fabricators', 'files', '60_keywords.csv')
+
+      visit keywords_path
+
+      within 'form' do
+        fill_in('username', with: user[:username])
+        fill_in('password', with: 'password')
+
+        click_button(I18n.t('auth.login'))
+      end
+
+      attach_file('csv_import_form[file]', file_path)
+
+      click_button(I18n.t('keyword.upload'))
+
+      visit keywords_path(page: 4)
+
+      expect(page).not_to have_selector('table')
+
+      expect(page).to have_content(I18n.t('keyword.no_keywords'))
+    end
+  end
+end

--- a/spec/systems/search_keywords_spec.rb
+++ b/spec/systems/search_keywords_spec.rb
@@ -8,9 +8,9 @@ describe 'search keywords', type: :system do
       user = Fabricate(:user)
       Fabricate(:keyword, user_id: user.id, keyword: 'AWS')
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')
@@ -38,9 +38,9 @@ describe 'search keywords', type: :system do
       user = Fabricate(:user)
       Fabricate(:keyword, user_id: user.id, keyword: 'AWS')
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')
@@ -68,9 +68,9 @@ describe 'search keywords', type: :system do
       user = Fabricate(:user)
       Fabricate(:keyword, user_id: user.id, keyword: 'AWS')
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')

--- a/spec/systems/upload_keywords_spec.rb
+++ b/spec/systems/upload_keywords_spec.rb
@@ -8,9 +8,9 @@ describe 'uploads csv file', type: :system do
       Fabricate(:user)
       file_path = Rails.root.join('spec', 'fabricators', 'files', 'example.csv')
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       attach_file('csv_import_form[file]', file_path)
 

--- a/spec/systems/view_keyword_list_spec.rb
+++ b/spec/systems/view_keyword_list_spec.rb
@@ -7,9 +7,9 @@ describe 'views keyword list', type: :system do
     it 'does NOT display table when no keywords' do
       Fabricate(:user)
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_content(I18n.t('keyword.no_keywords'))
@@ -26,9 +26,9 @@ describe 'views keyword list', type: :system do
       Fabricate(:keyword, user_id: user.id, keyword: 'Neymar')
       Fabricate(:keyword, user_id: user.id, keyword: 'Kevin De Bruyne')
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')
@@ -52,9 +52,9 @@ describe 'views keyword list', type: :system do
       user2 = Fabricate(:user, username: 'hello', password: 'password', password_confirmation: 'password')
       Fabricate(:keyword, user_id: user1[:id], keyword: 'Eden Hazard')
 
-      visit keywords_path
-
       system_login(user1.username, 'password')
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')
@@ -65,9 +65,9 @@ describe 'views keyword list', type: :system do
         click_link(I18n.t('auth.logout'))
       end
 
-      visit keywords_path
-
       system_login(user2.username, 'password')
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_content(I18n.t('keyword.no_keywords'))
@@ -79,9 +79,9 @@ describe 'views keyword list', type: :system do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
-      visit keywords_path
-
       system_login
+
+      visit keywords_path
 
       expect(current_path).to eql(keywords_path)
       expect(page).to have_selector('table')
@@ -96,9 +96,9 @@ describe 'views keyword list', type: :system do
         user = Fabricate(:user)
         Fabricate(:keyword, user_id: user.id, keyword: 'Eden Hazard')
 
-        visit keywords_path
-
         system_login
+
+        visit keywords_path
 
         expect(current_path).to eql(keywords_path)
         expect(page).to have_selector('table')
@@ -120,9 +120,9 @@ describe 'views keyword list', type: :system do
         user = Fabricate(:user)
         Fabricate(:keyword, user_id: user.id, keyword: 'Eden Hazard', status: :completed)
 
-        visit keywords_path
-
         system_login
+
+        visit keywords_path
 
         expect(current_path).to eql(keywords_path)
         expect(page).to have_selector('table')
@@ -142,9 +142,9 @@ describe 'views keyword list', type: :system do
         user = Fabricate(:user)
         Fabricate(:keyword, user_id: user.id, keyword: 'Eden Hazard', status: :failed)
 
-        visit keywords_path
-
         system_login
+
+        visit keywords_path
 
         expect(current_path).to eql(keywords_path)
         expect(page).to have_selector('table')

--- a/spec/systems/view_keyword_list_spec.rb
+++ b/spec/systems/view_keyword_list_spec.rb
@@ -75,7 +75,7 @@ describe 'views keyword list', type: :system do
       expect(page).not_to have_selector('table')
     end
 
-    it 'displays ONLY 50 keywords' do
+    it 'displays ONLY 25 keywords' do
       user = Fabricate(:user)
       Fabricate.times(60, :keyword, user_id: user.id, keyword: FFaker::Name.name)
 
@@ -87,7 +87,7 @@ describe 'views keyword list', type: :system do
       expect(page).to have_selector('table')
 
       within 'table tbody' do
-        expect(page).to have_selector('tr', count: 50)
+        expect(page).to have_selector('tr', count: 25)
       end
     end
 

--- a/spec/systems/view_scraping_result_spec.rb
+++ b/spec/systems/view_scraping_result_spec.rb
@@ -20,9 +20,9 @@ describe 'views scraping result', type: :system do
         non_adword_links: ['http://my.com', 'http://name.com', 'http://is.com']
       )
 
-      visit "#{keywords_path}/#{keyword.id}"
-
       system_login
+
+      visit "#{keywords_path}/#{keyword.id}"
 
       expect(current_path).to eql("#{keywords_path}/#{keyword.id}")
 
@@ -53,9 +53,9 @@ describe 'views scraping result', type: :system do
       user = Fabricate(:user)
       keyword = Fabricate(:keyword, user_id: user.id, keyword: 'AWS')
 
-      visit "#{keywords_path}/#{keyword.id}"
-
       system_login
+
+      visit "#{keywords_path}/#{keyword.id}"
 
       expect(current_path).to eql("#{keywords_path}/#{keyword.id}")
 
@@ -77,9 +77,9 @@ describe 'views scraping result', type: :system do
       user = Fabricate(:user)
       keyword = Fabricate(:keyword, user_id: user.id, keyword: 'AWS', status: :failed)
 
-      visit "#{keywords_path}/#{keyword.id}"
-
       system_login
+
+      visit "#{keywords_path}/#{keyword.id}"
 
       expect(current_path).to eql("#{keywords_path}/#{keyword.id}")
 


### PR DESCRIPTION
## What happened
- Add pagination to keywords list page

 
## Insight
- Use `Kaminari` to generate pagination
- Use `Kaminari` bootstrap 4 theme for pagination styling
- Limit 25 keywords per page 


## Proof Of Work
- Does not show pagination when keywords less than 25
![Screen Shot 2563-10-20 at 18 55 29](https://user-images.githubusercontent.com/29707647/96582706-e1439900-1305-11eb-8740-32e3209b21b5.png)

- Show 3 page when upload 60 keywords csv file
![Screen Shot 2563-10-20 at 18 56 49](https://user-images.githubusercontent.com/29707647/96582805-0506df00-1306-11eb-842d-6ba58b38636f.png)

- Last page show only 10 keywords
![Screen Shot 2563-10-20 at 18 57 22](https://user-images.githubusercontent.com/29707647/96582878-18b24580-1306-11eb-98de-34a50c92c9fe.png)

- Does not show keyword table when navigate to out of range page `(http://localhost:3000/keywords?page=4)`
![Screen Shot 2563-10-20 at 18 51 35](https://user-images.githubusercontent.com/29707647/96582302-49de4600-1305-11eb-99b6-744408cdbe81.png)
