### PR TITLE
Update command for Dockerfile worker

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -3,4 +3,4 @@ ARG DOCKER_IMAGE=nimblehq/ruby_google_scraper
 ARG DOCKER_REGISTRY=docker.io
 FROM ${DOCKER_REGISTRY}/${DOCKER_IMAGE}:${BRANCH_TAG}
 
-CMD ./bin/sidekiq.sh
+CMD bundle exec sidekiq -C config/sidekiq.yml


### PR DESCRIPTION
## What happened
As I deployed the scraping feature to Heroku and I tried to enable sidekiq worker but seem like we don't have `sidekiq.sh` in the bin folder

 
## Insight
- Update command for `Dockerfile.worker` (If this is the way to go, should we create an issue for rails template?)
 

## Proof Of Work
Worker would work on the production environment.
 