### PR TITLE
Add default db setting to production env

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,4 +18,5 @@ test:
   database: <%= ENV['DB_NAME'] %>_test
 
 production:
+  <<: *default
   url: <%= ENV['DATABASE_URL'] %>


### PR DESCRIPTION
## What happened
I got an error from CD workflow
```
Step 25/27 : RUN bundle exec rails i18n:js:export &&     bundle exec rails assets:precompile
 ---> Running in 987d9f6f1593
rails aborted!
ActiveRecord::AdapterNotSpecified: database configuration does not specify adapter
```

 
## Insight
- [x] Add default database setting to production env
 

## Proof Of Work
- [x] App able to pass the build step.
 